### PR TITLE
Add incompatibility with Vanilla Psycasts Expanded to About.xml 

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -21,6 +21,9 @@
 			<downloadUrl>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUrl>
 		</li>
 	</modDependencies>
+	<incompatibleWith>
+		<li>VanillaExpanded.VPsycastsE</li>
+	</incompatibleWith>
 	<loadAfter>
 		<li>brrainz.harmony</li>
 		<li>Ludeon.RimWorld.Royalty</li>

--- a/About/About.xml
+++ b/About/About.xml
@@ -22,8 +22,8 @@
 		</li>
 	</modDependencies>
 	<loadAfter>
-        <li>brrainz.harmony</li>
+		<li>brrainz.harmony</li>
 		<li>Ludeon.RimWorld.Royalty</li>
-    </loadAfter>
+	</loadAfter>
 <description>Allows manual selection of psycasts gained when increasing psylink level.</description>
 </ModMetaData>


### PR DESCRIPTION
Hi! Thank you for this mod!

The description mentions incompatibility with VPE. So maybe it'd be worthy to actually mirror this in the About.xml for the mod managers?

Did 2 commits here, one to amend minor whitespace mismatch, second to actually introduce new category. Tested locally that RimSort and the ingame mod manager complain about two mods together.